### PR TITLE
Cloudinary part III

### DIFF
--- a/server/bin/www.js
+++ b/server/bin/www.js
@@ -3,18 +3,18 @@
 /**
  * Module dependencies.
  */
-import "babel-polyfill";
-import app from "../app";
-import debugLib from "debug";
-import http from "http";
-const debug = debugLib("your-project-name:server");
-const socketio = require("socket.io");
+import 'babel-polyfill';
+import app from '../app';
+import debugLib from 'debug';
+import http from 'http';
+const debug = debugLib('your-project-name:server');
+const socketio = require('socket.io');
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || "3333");
-app.set("port", port);
+var port = normalizePort(process.env.PORT || '3333');
+app.set('port', port);
 
 /**
  * Create HTTP server.
@@ -26,34 +26,35 @@ var server = http.createServer(app);
  * so that we can access them later in the controller
  */
 const io = socketio(server);
-app.set("io", io);
+app.set('io', io);
 
 /**
  * Listen on provided port, on all network interfaces.
  */
 
 server.listen(port);
-server.on("error", onError);
-server.on("listening", onListening);
+server.on('error', onError);
+server.on('listening', onListening);
 
+server.timeout = 0;
 /**
  * Normalize a port into a number, string, or false.
  */
 
 function normalizePort(val) {
-  var port = parseInt(val, 10);
+	var port = parseInt(val, 10);
 
-  if (isNaN(port)) {
-    // named pipe
-    return val;
-  }
+	if (isNaN(port)) {
+		// named pipe
+		return val;
+	}
 
-  if (port >= 0) {
-    // port number
-    return port;
-  }
+	if (port >= 0) {
+		// port number
+		return port;
+	}
 
-  return false;
+	return false;
 }
 
 /**
@@ -61,25 +62,25 @@ function normalizePort(val) {
  */
 
 function onError(error) {
-  if (error.syscall !== "listen") {
-    throw error;
-  }
+	if (error.syscall !== 'listen') {
+		throw error;
+	}
 
-  var bind = typeof port === "string" ? "Pipe " + port : "Port " + port;
+	var bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port;
 
-  // handle specific listen errors with friendly messages
-  switch (error.code) {
-    case "EACCES":
-      console.error(bind + " requires elevated privileges");
-      process.exit(1);
-      break;
-    case "EADDRINUSE":
-      console.error(bind + " is already in use");
-      process.exit(1);
-      break;
-    default:
-      throw error;
-  }
+	// handle specific listen errors with friendly messages
+	switch (error.code) {
+		case 'EACCES':
+			console.error(bind + ' requires elevated privileges');
+			process.exit(1);
+			break;
+		case 'EADDRINUSE':
+			console.error(bind + ' is already in use');
+			process.exit(1);
+			break;
+		default:
+			throw error;
+	}
 }
 
 /**
@@ -87,7 +88,7 @@ function onError(error) {
  */
 
 function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === "string" ? "pipe " + addr : "port " + addr.port;
-  debug("Listening on " + bind);
+	var addr = server.address();
+	var bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port;
+	debug('Listening on ' + bind);
 }

--- a/server/db/seed.js
+++ b/server/db/seed.js
@@ -30,7 +30,7 @@ const seedDB = async () => {
 		}
 		const cloudinaryResult = await cloudinary.v2.uploader.upload(
 			`ignore/${fileName}`,
-			{ folder: '/publicMasks' },
+			{ folder: process.env.NODE_ENV === 'development' ? '/publicMasksDev' : '/publicMasks' },
 			(error, result) => {
 				if (error) {
 					console.log('Something went wrong while trying to save your Mask to Cloudinary.', error);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -213,7 +213,7 @@ async function triggerCloudGeneration(req, res, next) {
 			},
 		});
 		const { message } = data;
-		res.status(200).json({ cloud: newCloud.toObject(), message });
+		res.status(200).json({ cloud: { ...newCloud.toObject(), id: newCloud._id }, message });
 	} catch (err) {
 		console.log('SOMETHING WENT WRONG in triggerCloudGeneration', { err });
 		res.status(500).json({ err });
@@ -231,7 +231,7 @@ async function handleNewCloud(req, res, next) {
 		);
 		await rapCloud.save();
 		const io = req.app.get('io');
-		io.in(socketId).emit('RapCloudFinished', rapCloud.toObject());
+		io.in(socketId).emit('RapCloudFinished', { ...rapCloud.toObject(), id: rapCloud._id });
 		res.status(200).json({ message: 'Cloud is saved and sent back to client.' });
 	} catch (err) {
 		console.log('SOMETHING WENT WRONG in handleNewCloud', { err });

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -199,7 +199,7 @@ async function generateCloud(req, res, next) {
 		const cloudinaryResult = await cloudinary.v2.uploader.upload(
 			'tempCloud.png',
 			// `data:image/png;base64, ${encodedCloud}`, //TO-DO: Fix problem with using base64. Could be faster.
-			{ folder: '/userMadeClouds' },
+			{ folder: process.env.NODE_ENV === 'development' ? '/userMadeCloudsDev' : '/userMadeClouds' },
 			(error, result) => {
 				if (error) {
 					console.log('Something went wrong while trying to save your RapCloud to Cloudinary.', error);


### PR DESCRIPTION
Sisters 
- https://github.com/JordanTreDaniel/rapCloudsReact/pull/20
- https://github.com/JordanTreDaniel/wordCloudFlaskAPI/pull/4


- [x] Dev & prod versions of cloudinary folders
- [x] Fix async issue with creating clouds from temp.png
- [x] Don't allow Node to timeout
- [x] Move cloud actions around
- [x] Allow clouds to be deleted even if failed to upload to cloudinary
- [x] Unlock longer standing cloud generation!
	- General approach
		1. Cloud request on front end
		2. Saga calls the genCloud saga, which opens a websocket & records the id (must wait for 'connect' event)
			- https://socket.io/docs/v3/client-api/index.html#socket-disconnect
		3. Makes a call to initiate the cloud creation, sending cloud info and the socketId
		4. Backend gets the intiationCall, stores cloud, (meta info, no pic), and then initiates python scripts via API post call, passing on all info.
		5. Python receives the call, starts a cloudGeneration thread, - 
			- https://alyssaq.github.io/2014/how-do-I-return-a-http-response-to-caller-and-continue-processing/ 
			- https://docs.python.org/3/library/threading.html
		6. Python then responds, confirming cloud is being made
		7. Backend receives cloudGen confirmation, sends back to front end
		8. Front end basically ignores the cloudGenConfirmation
		9. When python is done generating the image, stores it in cloudinary, gets the info from cloudinary,
			- https://cloudinary.com/documentation/django_image_and_video_upload
		10. Python script sends an api call to the express backend, with all cloud info
		11. express backend emits a RapCloudReady event through the open socket, (using the socket id)
		12. Front end picks up the cloud, closes the socket, & passes it through sagas/reducers
	- Bonus:
		- With this approach, even if you close the page after requesting the mask, it will be there for you when you come back.
- [x] Use secure url to avoid "mixed" http/https
- [x] Store clouds after fetching them upon sign in
- [x] Implement deleteAllClouds to trim starting from DB
- [x] Implement pruneClouds to trim starting from Cloudinary
	- [x] Get all items
	- [x] Delete the items which are found to not have matching rapcloud or mask & are dev/not dev, depending on env
		- https://cloudinary.com/documentation/admin_api#resources 
- [ ] Set loading to true for clouds upon deletions
- [ ] Implement "pendingClouds" state
- [ ] Implement estimated wait time